### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ name: Go Tests
 
 on:
   push:
-    branches: 
-      - '**'
+    branches:
+      - 'main'
   pull_request:
     branches:
       - '**'
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23
+        go-version: 'stable'
 
     - name: Build
       run: go build -v ./...
@@ -28,6 +28,6 @@ jobs:
       run: go test -v ./...
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
-        version: v1.61
+        version: v2.1.6

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,26 +1,22 @@
-linters-settings:
-  gocyclo:
-    min-complexity: 25
-  govet:
-    check-shadowing: false
-  misspell:
-    locale: "US"
-
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
-    - musttag
-    - gci
-    - stylecheck
-    - gosec
-    - dupl
     - depguard
     - lll
-    - prealloc
-    - gocritic
-    - gochecknoinits
-    - gochecknoglobals
-    # These are deprecated
-    - execinquery
-    - exportloopref
-    - gomnd
+    - musttag
+  settings:
+    misspell:
+      locale: US
+    gosec:
+      excludes:
+        - G104 # Errors unhandled
+        - G304 # Potential file inclusion via variable
+  exclusions:
+    presets:
+      - std-error-handling
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports

--- a/cmd/sunlight-secretmanager/main.go
+++ b/cmd/sunlight-secretmanager/main.go
@@ -1,3 +1,9 @@
+// Sunlight-secretmanager creates new Sunlight CT Log instances, ensuring that
+// their signing keys are stored in an appropriate location.
+//
+// Usage:
+//
+//	sunlight-secretmanager -config /path/to/config.yaml
 package main
 
 import (

--- a/config/load_config.go
+++ b/config/load_config.go
@@ -1,3 +1,5 @@
+// Package config defines sunlight-secretmanager's yaml config format, and
+// provides utilities for loading and parsing a config file.
 package config
 
 import (

--- a/secrets/fetch_secrets.go
+++ b/secrets/fetch_secrets.go
@@ -1,3 +1,5 @@
+// Package secrets interacts with the AWS SecretManager API to retrieve secrets
+// and store them on a tmpfs.
 package secrets
 
 import (
@@ -20,6 +22,7 @@ type AWSSecretsManagerAPI interface {
 	GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
 }
 
+// Secrets provides access to secrets stored in AWS.
 type Secrets struct {
 	svc AWSSecretsManagerAPI
 }
@@ -27,6 +30,7 @@ type Secrets struct {
 // Filesystem represents a filesystem identifier as returned from fstatfs.
 type Filesystem int64
 
+// New uses the provided config to construct a new AWS Secret Manager client.
 func New(cfg aws.Config) *Secrets {
 	return &Secrets{
 		svc: secretsmanager.NewFromConfig(cfg),


### PR DESCRIPTION
Update golangci-lint to the latest release, and add a few doc-comments to satisfy some of the linters.