### PR TITLE
Fix small issues preventing sunlight-secretmanager from working

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,8 +2,9 @@ version: "2"
 linters:
   default: all
   disable:
-    - err113
     - depguard
+    - err113
+    - exhaustruct
     - lll
     - musttag
     - wsl

--- a/cmd/sunlight-secretmanager/config.go
+++ b/cmd/sunlight-secretmanager/config.go
@@ -16,9 +16,9 @@ type config struct {
 // logConfig is a subset of Sunlight's LogConfig. We use it to load just the
 // info we need about each individual log.
 type logConfig struct {
-	// Name is the unique human-readable identifier of the log. We use it for
-	// logging purposes.
-	Name string
+	// ShortName is the unique human-readable identifier of the log. We use it
+	// for logging purposes.
+	ShortName string
 	// Inception is the date at which the log will begin functioning. If the
 	// Inception date is in the future, and the Secret retrieved from AWS is
 	// empty, then sunlight-secretmanager will create a new secret. If the
@@ -50,8 +50,8 @@ func loadConfig(configFile string) (*config, error) {
 	}
 
 	for _, log := range sunlightConfig.Logs {
-		if log.Name == "" || log.Inception == "" || log.Secret == "" {
-			return nil, fmt.Errorf("incomplete config for log %q in config file %q", log.Name, configFile)
+		if log.ShortName == "" || log.Inception == "" || log.Secret == "" {
+			return nil, fmt.Errorf("incomplete config for log %q in config file %q", log.ShortName, configFile)
 		}
 	}
 

--- a/cmd/sunlight-secretmanager/config_test.go
+++ b/cmd/sunlight-secretmanager/config_test.go
@@ -52,12 +52,12 @@ func TestLoadConfig(t *testing.T) {
 			want: &config{
 				Logs: []logConfig{
 					{
-						ShortName: "test.tld/shard1",
+						ShortName: "shard1",
 						Inception: "2024-08-07",
 						Secret:    "/path/to/shard1.seed",
 					},
 					{
-						ShortName: "test.tld/shard2",
+						ShortName: "shard2",
 						Inception: "2024-08-07",
 						Secret:    "/path/to/shard2.seed",
 					},

--- a/cmd/sunlight-secretmanager/config_test.go
+++ b/cmd/sunlight-secretmanager/config_test.go
@@ -52,12 +52,12 @@ func TestLoadConfig(t *testing.T) {
 			want: &config{
 				Logs: []logConfig{
 					{
-						Name:      "test.tld/shard1",
+						ShortName: "test.tld/shard1",
 						Inception: "2024-08-07",
 						Secret:    "/path/to/shard1.seed",
 					},
 					{
-						Name:      "test.tld/shard2",
+						ShortName: "test.tld/shard2",
 						Inception: "2024-08-07",
 						Secret:    "/path/to/shard2.seed",
 					},

--- a/cmd/sunlight-secretmanager/main.go
+++ b/cmd/sunlight-secretmanager/main.go
@@ -56,12 +56,12 @@ func main() {
 	for _, logConf := range config.Logs {
 		seed, err := getOrCreateSeed(ctx, filepath.Base(logConf.Secret), logConf.Inception, smClient)
 		if err != nil {
-			log.Fatalf("Error getting seed for log %q: %v", logConf.Name, err)
+			log.Fatalf("Error getting seed for log %q: %v", logConf.ShortName, err)
 		}
 
 		err = writeFile(logConf.Secret, seed, *fileSystemFlag)
 		if err != nil {
-			log.Fatalf("Error persisting seed for log %q: %v", logConf.Name, err)
+			log.Fatalf("Error persisting seed for log %q: %v", logConf.ShortName, err)
 		}
 	}
 }

--- a/cmd/sunlight-secretmanager/seed.go
+++ b/cmd/sunlight-secretmanager/seed.go
@@ -18,7 +18,7 @@ const seedLen = 32
 // or equivalent implementation. This makes it easier to mock for testing.
 type SecretsManager interface {
 	GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
-	CreateSecret(ctx context.Context, params *secretsmanager.CreateSecretInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.CreateSecretOutput, error)
+	PutSecretValue(ctx context.Context, params *secretsmanager.PutSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.PutSecretValueOutput, error)
 }
 
 // fetchSeed retrieves a secret value from the provided SecretsManager.
@@ -48,19 +48,12 @@ func createSeed(ctx context.Context, smClient SecretsManager, id string) ([]byte
 	seed := make([]byte, seedLen)
 	_, _ = rand.Read(seed)
 
-	req := &secretsmanager.CreateSecretInput{
-		Name:                        aws.String(id),
-		AddReplicaRegions:           nil,
-		ClientRequestToken:          nil,
-		Description:                 nil,
-		ForceOverwriteReplicaSecret: false,
-		KmsKeyId:                    nil,
-		SecretBinary:                seed,
-		SecretString:                nil,
-		Tags:                        nil,
+	req := &secretsmanager.PutSecretValueInput{
+		SecretId:     aws.String(id),
+		SecretBinary: seed,
 	}
 
-	_, err := smClient.CreateSecret(ctx, req)
+	_, err := smClient.PutSecretValue(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("creating secret %q: %w", id, err)
 	}

--- a/cmd/sunlight-secretmanager/seed.go
+++ b/cmd/sunlight-secretmanager/seed.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 )
 
 // All Sunlight seeds must be exactly 32 bytes.
@@ -29,6 +31,10 @@ func fetchSeed(ctx context.Context, smClient SecretsManager, id string) ([]byte,
 
 	res, err := smClient.GetSecretValue(ctx, req)
 	if err != nil {
+		var notFound *types.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("retrieving secret %q: %w", id, err)
 	}
 

--- a/cmd/sunlight-secretmanager/seed.go
+++ b/cmd/sunlight-secretmanager/seed.go
@@ -33,7 +33,8 @@ func fetchSeed(ctx context.Context, smClient SecretsManager, id string) ([]byte,
 	if err != nil {
 		var notFound *types.ResourceNotFoundException
 		if errors.As(err, &notFound) {
-			return nil, nil
+			// Secret not found: return empty slice and nil error to indicate absence.
+			return []byte{}, nil
 		}
 
 		return nil, fmt.Errorf("retrieving secret %q: %w", id, err)
@@ -56,7 +57,7 @@ func createSeed(ctx context.Context, smClient SecretsManager, id string) ([]byte
 
 	_, err := smClient.PutSecretValue(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("creating secret %q: %w", id, err)
+		return nil, fmt.Errorf("putting secret value for %q: %w", id, err)
 	}
 
 	return seed, nil

--- a/cmd/sunlight-secretmanager/seed.go
+++ b/cmd/sunlight-secretmanager/seed.go
@@ -35,6 +35,7 @@ func fetchSeed(ctx context.Context, smClient SecretsManager, id string) ([]byte,
 		if errors.As(err, &notFound) {
 			return nil, nil
 		}
+
 		return nil, fmt.Errorf("retrieving secret %q: %w", id, err)
 	}
 

--- a/cmd/sunlight-secretmanager/seed_test.go
+++ b/cmd/sunlight-secretmanager/seed_test.go
@@ -38,8 +38,8 @@ func (sm *fakeSecretsManager) GetSecretValue(_ context.Context, params *secretsm
 	}
 }
 
-func (sm *fakeSecretsManager) CreateSecret(_ context.Context, params *secretsmanager.CreateSecretInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.CreateSecretOutput, error) {
-	if params.Name == nil || len(*params.Name) == 0 || len(params.SecretBinary) == 0 {
+func (sm *fakeSecretsManager) PutSecretValue(ctx context.Context, params *secretsmanager.PutSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.PutSecretValueOutput, error) {
+	if params.SecretId == nil || len(*params.SecretId) == 0 || len(params.SecretBinary) == 0 {
 		return nil, errors.New("incomplete request")
 	}
 
@@ -47,17 +47,16 @@ func (sm *fakeSecretsManager) CreateSecret(_ context.Context, params *secretsman
 		return nil, errors.New("can't specify both SecretBinary and SecretString")
 	}
 
-	if *params.Name == "error" {
-		return nil, fmt.Errorf("error 500 creating secret %q", *params.Name)
+	if *params.SecretId == "error" {
+		return nil, fmt.Errorf("error 500 creating secret %q", *params.SecretId)
 	}
 
 	if len(params.SecretBinary) != 32 {
 		return nil, fmt.Errorf("bad seed length: %d", len(params.SecretBinary))
 	}
 
-	return &secretsmanager.CreateSecretOutput{ //nolint:exhaustruct
-		ARN:       aws.String(*params.Name + "-123456"),
-		Name:      params.Name,
+	return &secretsmanager.PutSecretValueOutput{
+		ARN:       aws.String(*params.SecretId),
 		VersionId: aws.String("919108f7-52d1-4320-9bac-f847db4148a8"),
 	}, nil
 }

--- a/cmd/sunlight-secretmanager/seed_test.go
+++ b/cmd/sunlight-secretmanager/seed_test.go
@@ -136,7 +136,7 @@ func TestCreateSeed(t *testing.T) {
 		{
 			name:    "error",
 			id:      "error",
-			wantErr: "creating secret \"error\": error 500 creating secret",
+			wantErr: "putting secret value for \"error\": error 500 creating secret",
 		},
 		{
 			name:    "happy path",

--- a/cmd/sunlight-secretmanager/seed_test.go
+++ b/cmd/sunlight-secretmanager/seed_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 )
 
 type fakeSecretsManager struct{}
@@ -25,9 +26,7 @@ func (sm *fakeSecretsManager) GetSecretValue(_ context.Context, params *secretsm
 	case "missing":
 		return nil, fmt.Errorf("secret %q not found", *params.SecretId)
 	case "empty":
-		return &secretsmanager.GetSecretValueOutput{
-			Name: aws.String("empty"),
-		}, nil
+		return nil, &types.ResourceNotFoundException{Message: aws.String("secret does not exist")}
 	case "real":
 		return &secretsmanager.GetSecretValueOutput{
 			Name:         aws.String("real"),

--- a/cmd/sunlight-secretmanager/seed_test.go
+++ b/cmd/sunlight-secretmanager/seed_test.go
@@ -25,11 +25,11 @@ func (sm *fakeSecretsManager) GetSecretValue(_ context.Context, params *secretsm
 	case "missing":
 		return nil, fmt.Errorf("secret %q not found", *params.SecretId)
 	case "empty":
-		return &secretsmanager.GetSecretValueOutput{ //nolint:exhaustruct
+		return &secretsmanager.GetSecretValueOutput{
 			Name: aws.String("empty"),
 		}, nil
 	case "real":
-		return &secretsmanager.GetSecretValueOutput{ //nolint:exhaustruct
+		return &secretsmanager.GetSecretValueOutput{
 			Name:         aws.String("real"),
 			SecretBinary: []byte("hello world"),
 		}, nil
@@ -38,7 +38,7 @@ func (sm *fakeSecretsManager) GetSecretValue(_ context.Context, params *secretsm
 	}
 }
 
-func (sm *fakeSecretsManager) PutSecretValue(ctx context.Context, params *secretsmanager.PutSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.PutSecretValueOutput, error) {
+func (sm *fakeSecretsManager) PutSecretValue(_ context.Context, params *secretsmanager.PutSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.PutSecretValueOutput, error) {
 	if params.SecretId == nil || len(*params.SecretId) == 0 || len(params.SecretBinary) == 0 {
 		return nil, errors.New("incomplete request")
 	}


### PR DESCRIPTION
This fixes a few bugs in sunlight-secretsmanager found when trying to use it:

The "Name" value in config was deprecated and isn't in our current Sunlight configs - use shortname for logging instead

Trying to get a secret with no current version returns an error, which must be handled.

The code incorrectly used CreateSecret, but the secret already exists - we need to put content instead.