### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.3.0
+        version: v2.12.2
 
     - name: Vendorcheck
       shell: bash

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
     - depguard
     - err113
     - exhaustruct
+    - goconst
     - lll
     - musttag
     - wsl

--- a/cmd/sunlight-secretmanager/config_test.go
+++ b/cmd/sunlight-secretmanager/config_test.go
@@ -51,12 +51,12 @@ func TestLoadConfig(t *testing.T) {
 			input: "happy.yaml",
 			want: &config{
 				Logs: []logConfig{
-					{
+					{ //nolint:gosec // gosec thinks this is a hardcoded credential
 						ShortName: "shard1",
 						Inception: "2024-08-07",
 						Secret:    "/path/to/shard1.seed",
 					},
-					{
+					{ //nolint:gosec // gosec thinks this is a hardcoded credential
 						ShortName: "shard2",
 						Inception: "2024-08-07",
 						Secret:    "/path/to/shard2.seed",


### PR DESCRIPTION
Was failing CI

Remove the noisy goconst linter (which is unhappy about some of our repeated test strings) and two false positives from gosec