### PR TITLE
Update README.md for accuracy and Sunlight v0.9.0 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,18 @@
 # sunlight-secretmanager
 
 sunlight-secretmanager is a command-line tool to manage a
-[Sunlight](https://sunlight.dev/) CT Log's private key material.
+[Sunlight](https://sunlight.dev/) CT Log's seed material for its private key.
 
 All CT logs have a private key which they use to create Signed Certificate
 Timestamps (SCTs) and Signed Tree Heads (STHs). Sunlight does not take this
-private key as input directly. Instead, its configuration requires two file
-paths:
-
-- A seed file containing at least 32 bytes of random data, from which the log's
-  ECDSA P-256 key will be derived; and
-- A PEM file containing the corresponding ECDSA P-256 public key.
+private key as input directly. Instead, its configuration requires a seed file
+containing at least 32 bytes of random data, from which the log's ECDSA P-256
+key (and ML-DSA-44 key in v0.9.0 and above) will be derived.
 
 The purpose of sunlight-secretmanager is to authenticate to AWS Secrets Manager,
-retrieve a stored seed, use that seed to derive the corresponding pubkey, and
-write both files to disk in a tmpfs. It knows what seed to retrieve and where to
-write the output files by parsing the same config file which configures the
-Sunlight log itself.
+retrieve a stored seed, and write it to a file in a tmpfs. It knows what seed to
+retrieve and where to write the output file by parsing the same config file
+which configures the Sunlight log itself.
 
 If it successfully retrieves a secret from AWS Secrets Manager but that secret
 is empty, it will generate a new seed and save it back to AWS before proceeding.


### PR DESCRIPTION
Just some housekeeping on the readme to make it more accurate:
- This tool doesn't actually do any management or generation of key material--only the seed material.
- Sunlight v0.9.0 and above generates a ML-DSA-44 key to sign checkpoints.